### PR TITLE
fix telegraf user issues

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -101,10 +101,12 @@ class telegraf (
   validate_bool($manage_repo)
 
   contain ::telegraf::install
+  contain ::telegraf::user
   contain ::telegraf::config
   contain ::telegraf::service
 
   Class['::telegraf::install'] ->
+  Class['::telegraf::user'] ->
   Class['::telegraf::config'] ->
   Class['::telegraf::service']
 }

--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -1,0 +1,7 @@
+class telegraf::user {
+  user {'telegraf':
+    ensure => 'present',
+    home   => '/etc/telegraf',
+    shell  => '/bin/false'
+  }
+}


### PR DESCRIPTION
Introducing a user manifest. The user is installed before any configuration takes place (including telegraf config file permissions). Tested on around 6 boxes, both on working and non working ones. 