### PR TITLE
Telegraf watchdog based on local ports listening. MIT-759

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -18,13 +18,13 @@ class telegraf::service {
     if has_key( $::telegraf::inputs, 'tcp_listener') or has_key( $::telegraf::inputs, 'udp_listener') {
       # setup cronjob to check if ports are open and restart telegraf if not
       if has_key( $::telegraf::inputs, 'tcp_listener') and has_key( $::telegraf::inputs[tcp_listener], 'service_address') {
-        $tcp_port = split( $telegraf_inputs[tcp_listener][service_address], ':')[1]
+        $tcp_port = split( $::telegraf::inputs[tcp_listener][service_address], ':')[1]
         $tcp = "/bin/fuser -s -4 -n tcp ${tcp_port}"
       } else {
         $tcp = "/bin/true"
       }
       if has_key( $::telegraf::inputs, 'udp_listener') and has_key( $::telegraf::inputs[udp_listener], 'service_address') {
-        $udp_port = split( $telegraf_inputs[udp_listener][service_address], ':')[1]
+        $udp_port = split( $::telegraf::inputs[udp_listener][service_address], ':')[1]
         $udp = "/bin/fuser -s -4 -n udp ${udp_port}"
       } else {
         $udp = "/bin/true"

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -32,7 +32,7 @@ class telegraf::service {
       if "" != $tcp or "" != $udp {
         Package['lsof'] ->
         cron { 'ensure telegraf is listening on local ports':
-          command => "${lsof} ${tcp} ${udp} || ${restart} 1>/dev/null 2>/dev/null"
+          command => "bash -c '${lsof} ${tcp} ${udp} || ${restart}' >/dev/null 2>&1"
         }
       }
     }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -14,5 +14,27 @@ class telegraf::service {
       restart   => 'pkill -HUP telegraf',
       require   => Class['::telegraf::config'],
     }
+
+    if has_key( $::telegraf::inputs, 'tcp_listener') or has_key( $::telegraf::inputs, 'udp_listener') {
+      # setup cronjob to check if ports are open and restart telegraf if not
+      $lsof = "/usr/bin/lsof -n -P"
+      if has_key( $::telegraf::inputs, 'tcp_listener') and has_key( $::telegraf::inputs[tcp_listener], 'service_address') {
+        $tcp = "-i TCP@${::telegraf::inputs[tcp_listener][service_address]}"
+      } else {
+        $tcp = ""
+      }
+      if has_key( $::telegraf::inputs, 'udp_listener') and has_key( $::telegraf::inputs[udp_listener], 'service_address'){
+        $udp = "-i UDP@${::telegraf::inputs[udp_listener][service_address]}"
+      } else {
+        $udp = ""
+      }
+      $restart = "/usr/sbin/service telegraf restart"
+      if "" != $tcp or "" != $udp {
+        Package['lsof'] ->
+        cron { 'ensure telegraf is listening on local ports':
+          command => "${lsof} ${tcp} ${udp} || ${restart} 1>/dev/null 2>/dev/null"
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
Reads the expected TCP and/or UDP addresses and ports from the same configuration option that defines the Telegraf input listeners.
Relies on the package `lsof` being installed.
In case one of the expected ports is not listening, it will restart Telegraf service.