### PR TITLE
MIT-848: remove fuser crontab filtering for IPV4

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -19,13 +19,13 @@ class telegraf::service {
       # setup cronjob to check if ports are open and restart telegraf if not
       if has_key( $::telegraf::inputs, 'tcp_listener') and has_key( $::telegraf::inputs[tcp_listener], 'service_address') {
         $tcp_port = split( $::telegraf::inputs[tcp_listener][service_address], ':')[1]
-        $tcp = "/bin/fuser -s -4 -n tcp ${tcp_port}"
+        $tcp = "/bin/fuser -s -n tcp ${tcp_port}"
       } else {
         $tcp = "/bin/true"
       }
       if has_key( $::telegraf::inputs, 'udp_listener') and has_key( $::telegraf::inputs[udp_listener], 'service_address') {
         $udp_port = split( $::telegraf::inputs[udp_listener][service_address], ':')[1]
-        $udp = "/bin/fuser -s -4 -n udp ${udp_port}"
+        $udp = "/bin/fuser -s -n udp ${udp_port}"
       } else {
         $udp = "/bin/true"
       }


### PR DESCRIPTION
This prevents service restarts which cause vasts amounts of /tmp files