### PR TITLE
Telegraf config: allow multiple input/output definition with indices

### DIFF
--- a/templates/telegraf.conf.erb
+++ b/templates/telegraf.conf.erb
@@ -27,7 +27,7 @@
 # OUTPUTS:
 #
 <%   @outputs.sort.each do | output, options | -%>
-[[outputs.<%= output[0...-2]%>]]
+[[outputs.<%= output.gsub(/-?[0-9]+$/,'') %>]]
 <%      unless options == nil -%>
 <%          options.sort.each do | option, value | -%>
   <%= option -%> = <% if value.is_a?(String) %>"<%= value %>"<% elsif value.is_a?(Array) %><%= value.inspect %><% else %><%= value %><% end %>
@@ -41,7 +41,7 @@
 # INPUTS:
 #
 <%   @inputs.sort.each do | input, options | -%>
-[[inputs.<%= input %>]]
+[[inputs.<%= input.gsub(/-?[0-9]+$/,'') %>]]
 <%      unless options == nil -%>
 <%          options.sort.each do | option, value | -%>
   <%= option -%> = <% if value.is_a?(String) %>"<%= value %>"<% elsif value.is_a?(Array) %><%= value.inspect %><% else %><%= value %><% end %>


### PR DESCRIPTION
This substitution works for both inputs and outputs
It will respect when you declare a single input with no index number, with index number directly appended at the end of the name, or separated with a dash.
It will also accept indices with any number of digits.
Previous versions of the substitution will remove the last 2 chars from the output name regardless, forcing you to always append 2 digits at the end of an output name even if you declare only one

Now you can declare outputs or inputs in any of the following formats:
```
telegraf::outputs:
  influxdb:
```
```
telegraf::outputs:
  influxdb-05:
```
```
telegraf::inputs:
 socket_listener1:
```
```
telegraf::inputs:
 socket_listener123:
```

The parsed config file will strip the dash (if existing) and any trailing digits from the input or output name