### PR TITLE
MIT-1488: Telegraf service: force proper restart on service refresh

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -11,7 +11,6 @@ class telegraf::service {
       ensure    => running,
       hasstatus => true,
       enable    => true,
-      restart   => 'pkill -HUP telegraf',
       require   => Class['::telegraf::config'],
     }
 


### PR DESCRIPTION
Remove the `restart` command from the service definition, so the service does `stop && start` instead upon service refreshes in puppet.
This is forced this way to deal with the issues described in https://office.brandwatch.com/jira/browse/MIT-1488

According to documentation, removing this `restart` has the desired effect. Tests confirmed it.
https://puppet.com/docs/puppet/5.1/types/service.html#service-attribute-restart