### PR TITLE
NT-improve-config-file-template

### DIFF
--- a/templates/input.conf.erb
+++ b/templates/input.conf.erb
@@ -11,7 +11,11 @@
 [[inputs.<%= key %>]]
 <% @sections[key].keys.sort.each do |value| -%>
 <% if @sections[key][value].is_a?(String) -%>
+<% if @sections[key][value] =~ /[\x00-\x08\x10-\x19\x22\x5c\x7f]/ -%>
+  <%= value %> = """<%= @sections[key][value] %>"""
+<% else -%>
   <%= value %> = "<%= @sections[key][value] %>"
+<% end -%>
 <% else -%>
   <%= value %> = <%= @sections[key][value] %>
 <% end -%>


### PR DESCRIPTION
still not bulletproof and not for all values, but better than before, where quotation marks and newlines were not allowed in values