### PR TITLE
Updating Telegraf configuration file template

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,12 +20,13 @@
 # [*round_interval*]
 #   Boolean. Rounds collection interval to 'interval'
 #
+# [*metric_batch_size*]
+#   Integer. Cache metric_batch_size metrics for each output, and flush this
+#   buffer on a successful write.
+#
 # [*metric_buffer_limit*]
 #   Integer. Cache metric_buffer_limit metrics for each output, and flush this
 #   buffer on a successful write.
-#
-# [*flush_buffer_when_full*]
-#   Boolean. Flush buffer whenever full, regardless of flush_interval
 #
 # [*collection_jitter*]
 #   String.  Sleep for a random time within jitter before collecting.
@@ -66,8 +67,8 @@ class telegraf (
   $hostname               = $telegraf::params::hostname,
   $interval               = $telegraf::params::interval,
   $round_interval         = $telegraf::params::round_interval,
+  $metric_batch_size      = $telegraf::params::metric_batch_size,
   $metric_buffer_limit    = $telegraf::params::metric_buffer_limit,
-  $flush_buffer_when_full = $telegraf::params::flush_buffer_when_full,
   $collection_jitter      = $telegraf::params::collection_jitter,
   $flush_interval         = $telegraf::params::flush_interval,
   $flush_jitter           = $telegraf::params::flush_jitter,
@@ -87,8 +88,8 @@ class telegraf (
   validate_string($hostname)
   validate_string($interval)
   validate_bool($round_interval)
+  validate_integer($metric_batch_size)
   validate_integer($metric_buffer_limit)
-  validate_bool($flush_buffer_when_full)
   validate_string($collection_jitter)
   validate_string($flush_interval)
   validate_string($flush_jitter)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,8 +9,8 @@ class telegraf::params {
   $hostname               = $::hostname
   $interval               = '10s'
   $round_interval         = true
+  $metric_batch_size      = '1000'
   $metric_buffer_limit    = '1000'
-  $flush_buffer_when_full = true
   $collection_jitter      = '0s'
   $flush_interval         = '10s'
   $flush_jitter           = '0s'

--- a/templates/telegraf.conf.erb
+++ b/templates/telegraf.conf.erb
@@ -13,8 +13,8 @@
   hostname = "<%= @hostname %>"
   interval = "<%= @interval %>"
   round_interval = <%= @round_interval %>
+  metric_batch_size = <%= @metric_batch_size %>
   metric_buffer_limit = <%= @metric_buffer_limit %>
-  flush_buffer_when_full = <%= @flush_buffer_when_full %>
   collection_jitter = "<%= @collection_jitter %>"
   flush_interval = "<%= @flush_interval %>"
   flush_jitter = "<%= @flush_jitter %>"


### PR DESCRIPTION
Removing flush_buffer_when_full as it has been removed from Telegraf completely
https://github.com/influxdata/telegraf/blob/master/CHANGELOG.md#v013-2016-05-11 (item 3)

Adding metric_batch_size to allow setting batch size
https://github.com/influxdata/telegraf/blob/master/CHANGELOG.md#v013-2016-05-11 (item 2)

Result of change
```shell
Notice: /Stage[main]/Telegraf::Config/File[/etc/telegraf/telegraf.conf]/content:
--- /etc/telegraf/telegraf.conf	2020-06-22 13:30:56.250376941 +0000
+++ /tmp/puppet-file20210225-128812-zj8eq9	2021-02-25 15:47:22.607895108 +0000
@@ -8,8 +8,8 @@
   hostname = "ssl-proxy1"
   interval = "30s"
   round_interval = true
-  metric_buffer_limit = 1000
-  flush_buffer_when_full = true
+  metric_batch_size = 1000
+  metric_buffer_limit = 2000
   collection_jitter = "0s"
   flush_interval = "30s"
   flush_jitter = "5s"

Info: Computing checksum on file /etc/telegraf/telegraf.conf
```